### PR TITLE
Refactor DeepObjectMerger, add unit tests

### DIFF
--- a/src/main/java/org/ga4gh/drs/AppConfig.java
+++ b/src/main/java/org/ga4gh/drs/AppConfig.java
@@ -112,8 +112,7 @@ public class AppConfig implements WebMvcConfigurer {
         @Qualifier (AppConfigConstants.DEFAULT_DRS_CONFIG_CONTAINER) DrsConfigContainer defaultContainer,
         @Qualifier (AppConfigConstants.RUNTIME_DRS_CONFIG_CONTAINER) DrsConfigContainer runtimeContainer
     ) {
-        DeepObjectMerger merger = new DeepObjectMerger();
-        merger.merge(runtimeContainer, defaultContainer);
+        DeepObjectMerger.merge(runtimeContainer, defaultContainer);
         return defaultContainer;
     }
 }

--- a/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
+++ b/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
@@ -2,13 +2,13 @@ package org.ga4gh.drs.utils;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class DeepObjectMerger {
 
-    private static final Set<Class<?>> primClasses = new HashSet<>(Arrays.asList(
+    private static final Set<Class<?>> classesToSet = new HashSet<>(Arrays.asList(
+        List.class,
+        ArrayList.class,
         String.class,
         LocalDateTime.class,
         boolean.class,
@@ -35,11 +35,10 @@ public class DeepObjectMerger {
                 Object sourceProperty = field.get(source);
                 Object targetProperty = field.get(target);
 
-
                 // If the field is a 'primitive' type, then the target field
                 // can be set with the source field value (provided source
                 // field value is not null)
-                if (primClasses.contains(fieldClass)) {
+                if (classesToSet.contains(fieldClass)) {
                     if (sourceProperty != null) {
                         field.set(target, sourceProperty);
                     }

--- a/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
+++ b/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
@@ -1,62 +1,54 @@
 package org.ga4gh.drs.utils;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 public class DeepObjectMerger {
 
-    private static final Set<String> primitives = new HashSet<>(Arrays.asList(
-        "java.lang.String",
-        "java.time.LocalDateTime",
-        "java.util.List"
+    private static final Set<Class<?>> primClasses = new HashSet<>(Arrays.asList(
+        String.class,
+        LocalDateTime.class,
+        boolean.class,
+        byte.class,
+        short.class,
+        char.class,
+        int.class,
+        long.class,
+        float.class,
+        double.class
     ));
 
-    public DeepObjectMerger() {
-
-    }
-
-    public void merge(Object source, Object target) {
-        // through reflection, get all fields associated with object to be 
-        // merged
+    public static void merge(Object source, Object target) {
+        // Through reflection, get all fields associated with object to be merged
         Class<?> objectClass = source.getClass();
         Field[] fields = objectClass.getDeclaredFields();
-        
-        for (Field field: fields) {
-            // get field name, class, and associated getter and setter
+
+        for (Field field : fields) {
+            // Get field and set as accessible so it can be written
             Class<?> fieldClass = field.getType();
-            String fieldClassName = fieldClass.getName();
-            String fieldName = field.getName();
-            String getterName = "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
-            String setterName = "set" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+            field.setAccessible(true);
 
             try {
-                // call the getter to get the value for both source and target
-                // objects
-                Method getter = objectClass.getDeclaredMethod(getterName);
-                Object sourceProperty = getter.invoke(source, (Object[]) null);
-                Object targetProperty = getter.invoke(target, (Object[]) null);
+                Object sourceProperty = field.get(source);
+                Object targetProperty = field.get(target);
 
-                // if the field is a 'primitive' type, then the target field
+
+                // If the field is a 'primitive' type, then the target field
                 // can be set with the source field value (provided source
                 // field value is not null)
-                if (primitives.contains(fieldClassName)) {
+                if (primClasses.contains(fieldClass)) {
                     if (sourceProperty != null) {
-                        Method setter = objectClass.getDeclaredMethod(setterName, fieldClass);
-                        setter.invoke(target, sourceProperty);
+                        field.set(target, sourceProperty);
                     }
-                // if the field is a complex class (i.e. non-primitive), then
+                }
+                // If the field is a complex class (i.e. non-primitive), then
                 // this method is recursively called on the field value
-                } else {
+                else {
                     merge(sourceProperty, targetProperty);
                 }
-            } catch (NoSuchMethodException e) {
-                System.out.println("no such method");
-            } catch (InvocationTargetException e) {
-                System.out.println("invocation target exception");
             } catch (IllegalAccessException e) {
                 System.out.println("illegal access exception");
             }

--- a/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
+++ b/src/main/java/org/ga4gh/drs/utils/DeepObjectMerger.java
@@ -43,11 +43,17 @@ public class DeepObjectMerger {
                     if (sourceProperty != null) {
                         field.set(target, sourceProperty);
                     }
-                }
-                // If the field is a complex class (i.e. non-primitive), then
-                // this method is recursively called on the field value
-                else {
-                    merge(sourceProperty, targetProperty);
+                } else {
+                    // If the field is a complex class (i.e. non-primitive),
+                    // and both source and target are non-null, then
+                    // this method is recursively called on the field value
+                    if (sourceProperty != null && targetProperty != null) {
+                        merge(sourceProperty, targetProperty);
+                    }
+                    // Null target field can be set with source field value
+                    else if (sourceProperty != null) {
+                        field.set(target, sourceProperty);
+                    }
                 }
             } catch (IllegalAccessException e) {
                 System.out.println("illegal access exception");

--- a/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
+++ b/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
@@ -44,7 +44,7 @@ public class DeepObjectMergerTest {
     }
 
     @Test
-    public void testNullSourceIgnored() {
+    public void testNullPrimitiveSourceIgnored() {
         LocalDateTime dt = LocalDateTime.now();
 
         Simple target = new Simple("s", dt, false);
@@ -58,7 +58,7 @@ public class DeepObjectMergerTest {
     }
 
     @Test
-    public void testNonNullSourceCopied() {
+    public void testNonNullPrimitiveSourceCopied() {
         LocalDateTime dt = LocalDateTime.now();
 
         Simple target = new Simple("s", null, false);
@@ -72,7 +72,25 @@ public class DeepObjectMergerTest {
     }
 
     @Test
-    public void testComplexFieldsMerged() {
+    public void testNullComplexSourceIgnored() {
+        LocalDateTime dt = LocalDateTime.now();
+
+        Simple simpleTarget = new Simple("s", dt, true);
+
+        Complex complexTarget = new Complex(simpleTarget);
+        Complex complexSource = new Complex(null);
+
+        DeepObjectMerger.merge(complexSource, complexTarget);
+
+        Simple mergedTarget = complexTarget.getS();
+
+        Assert.assertEquals(mergedTarget.getS(), "s");
+        Assert.assertEquals(mergedTarget.getDt(), dt);
+        Assert.assertTrue(mergedTarget.isB());
+    }
+
+    @Test
+    public void testNonNullComplexSourceMerged() {
         LocalDateTime dt = LocalDateTime.now();
 
         Simple simpleTarget = new Simple("s", null, false);

--- a/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
+++ b/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
@@ -4,6 +4,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public class DeepObjectMergerTest {
 
@@ -106,5 +108,28 @@ public class DeepObjectMergerTest {
         Assert.assertEquals(mergedTarget.getS(), "t");
         Assert.assertEquals(mergedTarget.getDt(), dt);
         Assert.assertTrue(mergedTarget.isB());
+    }
+
+    private static class HasList {
+        List<String> strings;
+
+        public HasList(List<String> strings) {
+            this.strings = strings;
+        }
+
+        public List<String> getStrings() {
+            return strings;
+        }
+    }
+
+    @Test
+    public void testCollectionsCopied() {
+        HasList target = new HasList(Arrays.asList("a", "b"));
+        HasList source = new HasList(Arrays.asList("c", "d"));
+
+        DeepObjectMerger.merge(source, target);
+
+        Assert.assertEquals(target.getStrings().get(0), "c");
+        Assert.assertEquals(target.getStrings().get(1), "d");
     }
 }

--- a/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
+++ b/src/test/java/org/ga4gh/drs/utils/DeepObjectMergerTest.java
@@ -1,0 +1,92 @@
+package org.ga4gh.drs.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+
+public class DeepObjectMergerTest {
+
+    private static class Simple {
+        private String s;
+        private LocalDateTime dt;
+        private boolean b;
+
+        public Simple(String s, LocalDateTime dt, boolean b) {
+            this.s = s;
+            this.dt = dt;
+            this.b = b;
+        }
+
+        public String getS() {
+            return s;
+        }
+
+        public LocalDateTime getDt() {
+            return dt;
+        }
+
+        public boolean isB() {
+            return b;
+        }
+    }
+
+    private static class Complex {
+        private Simple s;
+
+        public Complex(Simple s) {
+            this.s = s;
+        }
+
+        public Simple getS() {
+            return s;
+        }
+    }
+
+    @Test
+    public void testNullSourceIgnored() {
+        LocalDateTime dt = LocalDateTime.now();
+
+        Simple target = new Simple("s", dt, false);
+        Simple source = new Simple(null, null, true);
+
+        DeepObjectMerger.merge(source, target);
+
+        Assert.assertEquals(target.getS(), "s");
+        Assert.assertEquals(target.getDt(), dt);
+        Assert.assertTrue(target.isB());
+    }
+
+    @Test
+    public void testNonNullSourceCopied() {
+        LocalDateTime dt = LocalDateTime.now();
+
+        Simple target = new Simple("s", null, false);
+        Simple source = new Simple("t", dt, true);
+
+        DeepObjectMerger.merge(source, target);
+
+        Assert.assertEquals(target.getS(), "t");
+        Assert.assertEquals(target.getDt(), dt);
+        Assert.assertTrue(target.isB());
+    }
+
+    @Test
+    public void testComplexFieldsMerged() {
+        LocalDateTime dt = LocalDateTime.now();
+
+        Simple simpleTarget = new Simple("s", null, false);
+        Simple simpleSource = new Simple("t", dt, true);
+
+        Complex complexTarget = new Complex(simpleTarget);
+        Complex complexSource = new Complex(simpleSource);
+
+        DeepObjectMerger.merge(complexSource, complexTarget);
+
+        Simple mergedTarget = complexTarget.getS();
+
+        Assert.assertEquals(mergedTarget.getS(), "t");
+        Assert.assertEquals(mergedTarget.getDt(), dt);
+        Assert.assertTrue(mergedTarget.isB());
+    }
+}


### PR DESCRIPTION
* Change class to static utility class
* Compare class objects directly when checking for primitives
* Use Field get and set methods
@jb-adams 